### PR TITLE
CA update

### DIFF
--- a/Block/Payment/Success.php
+++ b/Block/Payment/Success.php
@@ -1,0 +1,16 @@
+<?php
+namespace Affirm\Telesales\Block\Payment;
+
+/**
+ * Success constructor.
+ * @param \Magento\Backend\Block\Template\Context $context
+ *
+ */
+class Success extends \Magento\Framework\View\Element\Template
+{
+    public function __construct(
+        \Magento\Framework\View\Element\Template\Context $context
+    ) {
+        parent::__construct($context);
+    }
+}

--- a/Controller/Payment/Confirm.php
+++ b/Controller/Payment/Confirm.php
@@ -1,18 +1,20 @@
 <?php
 namespace Affirm\Telesales\Controller\Payment;
 
+use Affirm\Telesales\Model\Adminhtml\Checkout as AffirmCheckout;
+use Magento\Checkout\Model\Session;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\CsrfAwareActionInterface;
-use Magento\Framework\App\RequestInterface;
 use Magento\Framework\App\Request\InvalidRequestException;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Checkout\Model\Session;
 use Magento\Quote\Api\CartManagementInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
-use Magento\Sales\Model\OrderFactory;
 use Magento\Sales\Api\OrderManagementInterface as OrderManagement;
-use Affirm\Telesales\Model\Adminhtml\Checkout as AffirmCheckout;
+use Magento\Sales\Model\OrderFactory;
+use Affirm\Telesales\Helper\Data as AffirmData;
 
 class Confirm extends Action implements CsrfAwareActionInterface
 {
@@ -30,8 +32,10 @@ class Confirm extends Action implements CsrfAwareActionInterface
         OrderManagement $orderManagement,
         CartRepositoryInterface $quoteRepository,
         AffirmCheckout $affirmCheckout,
+        JsonFactory $resultJsonFactory,
+        AffirmData $affirmData,
         \Psr\Log\LoggerInterface $logger
-    )	{
+    ) {
         parent::__construct($context);
         $this->_checkoutSession = $checkoutSession;
         $this->quoteManagement = $cartManagement;
@@ -39,6 +43,8 @@ class Confirm extends Action implements CsrfAwareActionInterface
         $this->orderManagement = $orderManagement;
         $this->quoteRepository = $quoteRepository;
         $this->affirmCheckout = $affirmCheckout;
+        $this->resultJsonFactory = $resultJsonFactory;
+        $this->affirmData = $affirmData;
         $this->logger = $logger;
     }
 
@@ -58,39 +64,65 @@ class Confirm extends Action implements CsrfAwareActionInterface
     {
         return true;
     }
-    
-     /**
-     * @inheritDoc
-     */
+
+    /**
+    * @inheritDoc
+    */
     public function execute()
     {
-        $checkout_token = $this->getRequest()->getParam('checkout_token');
-        $this->logger->debug('Affirm Telesales checkout confirm action: '.$checkout_token);
-        if (!isset($checkout_token)) {
-            return $this->cancelRedirect();
+        $result = $this->resultJsonFactory->create();
+        $checkout_token = $this->getRequest()->getParam('checkout_token') ?? null;
+        $currency_code = $this->getRequest()->getParam('currency_code') ?? 'USD';
+        $this->logger->debug('Affirm Telesales checkout confirm action: ' . $checkout_token);
+        if (!$checkout_token) {
+            $result->setData([
+                'success' => true,
+                'checkout_status' => "Not sent",
+                'checkout_status_message' => "Send checkout link to customer"
+            ]);
+            return $result;
         }
 
         // Get orderIncrementId from checkout read
-        $readCheckoutResponse = $this->affirmCheckout->readCheckout($checkout_token);
-        $responseBody = json_decode($readCheckoutResponse->getBody(), true);
-        $order_id = $responseBody['merchant_external_reference'] ?: $responseBody['order_id'];
-        $checkout_status = $responseBody['checkout_status'];
+        $checkout_status = '';
+        try {
+            $readCheckoutResponse = $this->affirmCheckout->readCheckout($checkout_token, $currency_code);
+            $response_date = $readCheckoutResponse->getHeader('Date');
+            $this->logger->debug('Affirm Telesales checkout confirm responseBody: ' . $readCheckoutResponse->getBody());
+            $responseBody = json_decode($readCheckoutResponse->getBody(), true);
+            if (isset($responseBody['checkout_status'])) {
+                $checkout_status = $responseBody['checkout_status'];
+            }
+            $test = $this->affirmData->mapResponseToMessage($responseBody);
+        } catch (\Exception $e) {
+            $this->logger->debug('Affirm Telesales checkout confirm error: ' . $e);
+            return $this->getErrorResult($result, $e)
+        }
+
+        // Verify checkout_token and checkout_status
+        if ($checkout_status !== 'confirmed' && $checkout_status !=='authorized') {
+            $result->setData([
+                'success' => true,
+                'message' => "Last refreshed: " . $response_date,
+                'checkout_status' => "Application sent",
+                'checkout_status_message' => "Waiting for customer to start the application"
+            ]);
+            return $result;
+        }
+
+        // Order ID
+        $order_id = $responseBody['merchant_external_reference'] ?? $responseBody['order_id'];
 
         if (!isset($order_id)) {
-            $this->logger->debug('Affirm Telesales - Missing merchant external reference');
-            return $this->cancelRedirect();
+            $_message = __('Affirm Telesales - Missing merchant external reference')
+            $this->logger->debug($_message);
+            return $this->getErrorResult($result, $_message);
         }
 
         // Load order
         $_order = $this->orderFactory->create()->loadByIncrementId($order_id);
         $quoteId = $_order->getQuoteId();
         $quote = $this->quoteRepository->get($quoteId);
-
-        // Verify checkout_token and checkout_status
-        if ($checkout_token !== $_order->getPayment()->getAdditionalInformation('checkout_token') || $checkout_status !== self::CHECKOUT_STATUS_CONFIRMED) {
-            $this->logger->debug('Affirm Telesales - Invalid checkout token');
-            return $this->cancelRedirect();
-        }
 
         // Set checkout_token to quote
         $payment = $quote->getPayment();
@@ -109,18 +141,17 @@ class Confirm extends Action implements CsrfAwareActionInterface
             $_order->addCommentToStatusHistory($e->getMessage());
             $_order->save();
 
-            return $this->cancelRedirect();
+            return $this->getErrorResult($result, $e);
         } catch (\Exception $e) {
             $this->messageManager->addExceptionMessage(
                 $e,
                 __('We can\'t place the order.')
             );
-            return $this->cancelRedirect();
+            return $this->getErrorResult($result, $e);
         }
 
         $_orderState = $order->getState();
         $_orderStatus = $order->getStatus();
-
 
         $this->_checkoutSession
             ->setLastQuoteId($quoteId)
@@ -135,14 +166,21 @@ class Confirm extends Action implements CsrfAwareActionInterface
             ['order' => $order, 'quote' => $quote ]
         );
 
-        $this->_redirect('checkout/onepage/success');
-        return;
+        $result->setData([
+            'success' => true,
+            'message' => "Success",
+            'checkout_status' => "Payment authorized",
+            'checkout_status_message' => "Payment is complete. Ready to finalize order"
+        ]);
+        return $result;
     }
 
-    private function cancelRedirect() {
-        $resultRedirect = $this->resultRedirectFactory->create();
-        $resultRedirect->setPath('telesales/payment/cancel');
-        return $resultRedirect;
+    private function getErrorResult($result, $e)
+    {
+        $result->setData([
+            'success' => false,
+            'message' => $e
+        ])
+        return $result;
     }
-
 }

--- a/Controller/Payment/Confirm.php
+++ b/Controller/Payment/Confirm.php
@@ -96,7 +96,7 @@ class Confirm extends Action implements CsrfAwareActionInterface
             $test = $this->affirmData->mapResponseToMessage($responseBody);
         } catch (\Exception $e) {
             $this->logger->debug('Affirm Telesales checkout confirm error: ' . $e);
-            return $this->getErrorResult($result, $e)
+            return $this->getErrorResult($result, $e);
         }
 
         // Verify checkout_token and checkout_status
@@ -114,7 +114,7 @@ class Confirm extends Action implements CsrfAwareActionInterface
         $order_id = $responseBody['merchant_external_reference'] ?? $responseBody['order_id'];
 
         if (!isset($order_id)) {
-            $_message = __('Affirm Telesales - Missing merchant external reference')
+            $_message = __('Affirm Telesales - Missing merchant external reference');
             $this->logger->debug($_message);
             return $this->getErrorResult($result, $_message);
         }
@@ -180,7 +180,7 @@ class Confirm extends Action implements CsrfAwareActionInterface
         $result->setData([
             'success' => false,
             'message' => $e
-        ])
+        ]);
         return $result;
     }
 }

--- a/Controller/Payment/Success.php
+++ b/Controller/Payment/Success.php
@@ -1,0 +1,31 @@
+<?php
+namespace Affirm\Telesales\Controller\Payment;
+
+use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\View\Result\PageFactory;
+
+class Success extends Action
+{
+    protected $_pageFactory;
+
+    public function __construct(
+        Context $context,
+        PageFactory $pageFactory
+    )   {
+        $this->_pageFactory = $pageFactory;
+        parent::__construct($context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute()
+    {
+        $messages = $this->messageManager->getMessages();
+        if ($messages) {
+            $this->messageManager->addErrorMessage($messages);
+        }
+        return $this->_pageFactory->create();
+    }
+}

--- a/view/adminhtml/templates/telesales.phtml
+++ b/view/adminhtml/templates/telesales.phtml
@@ -5,6 +5,7 @@
 $paymentCheckoutToken = $block->getPaymentCheckoutToken();
 $readCheckoutResult = $block->getReadCheckoutAPI();
 $isAffirmPaymentMethod = $block->isAffirmPaymentMethod();
+$currencyCode = $block->getCurrencyCode();
 
 if ($readCheckoutResult && $isAffirmPaymentMethod) {
 ?>
@@ -52,7 +53,7 @@ if ($readCheckoutResult && $isAffirmPaymentMethod) {
 
                         if (success) {
                             sendCheckoutSpan.find('.success').show();
-                            _$('#send_checkout_button > span').text("Re-send Affirm Checkout Link");
+                            window.location.reload();
                         } else {
                             sendCheckoutSpan.find('.fail').show();
                         }
@@ -67,16 +68,72 @@ if ($readCheckoutResult && $isAffirmPaymentMethod) {
             });
         });
 
+        // Send Auth Button
+        _$('#send_auth_button').click(function () {
+            const params = {
+                'checkout_token': '<?php echo $paymentCheckoutToken ?>',
+                'currency_code': '<?php echo $currencyCode ?>'
+            };
+            new Ajax.Request('<?php echo $block->getAjaxUrlConfirm() ?>', {
+                parameters:     params,
+                loaderArea:     false,
+                asynchronous:   true,
+                onCreate: function() {
+                    _$('#send_auth_button').prop('disabled', true);
+                    sendCheckoutSpan.find('.success').hide();
+                    sendCheckoutSpan.find('.fail').hide();
+                    sendCheckoutSpan.find('.processing').show();
+                    _$('#send_auth_message').text('');
+                },
+                onSuccess: function(response) {
+                    sendCheckoutSpan.find('.processing').hide();
+                    _$('#send_auth_button').prop('disabled', false);
+                    console.log(response);
+                    if (response.status > 200) {
+                        sendCheckoutSpan.find('.fail').show();
+                        _$('#send_auth_message').text('Error');
+                    } else {
+                        var jsonResponse = response.responseJSON || {};
+                        var success = jsonResponse.success || null;
+                        var message = jsonResponse.message || null;
+                        var checkout_status = jsonResponse.checkout_status || null;
+                        var checkout_status_message = jsonResponse.checkout_status_message || null;
+                        var checkout_action = jsonResponse.checkout_action || null;
+
+                        if (success) {
+                            sendCheckoutSpan.find('.success').show();
+                            window.location.reload();
+                        } else {
+                            sendCheckoutSpan.find('.fail').show();
+                        }
+
+                        if (message || checkout_status || checkout_status_message) {
+                            _$('#send_checkout_message').text(message);
+                            _$('#checkout_status').text(checkout_status);
+                            _$('#checkout_status_message').text(checkout_status_message);
+                        }
+                    }
+                }
+            });
+        });
+
     });
 </script>
 <?php if ($readCheckoutResult['checkout_action']): ?>
 <div class="affirm-telesales-checkout-actions" style="margin-top: 1.7rem">
     <?php echo $block->getSendCheckoutButtonHtml() ?>
-    <span class="collect-indicator" id="send_checkout_span">
+    <?php echo $block->getSendAuthButtonHtml() ?>
+    <span class="collect-indicator" id="send_checkout_span" style="display: block; margin-top: 1rem;">
         <img class="processing" hidden="hidden" alt="Fetching" style="margin:0 5px; vertical-align: middle;" src="<?php echo $block->getViewFileUrl('images/process_spinner.gif') ?>"/>
         <img class="success" hidden="hidden" alt="Success" style="margin:-3px 5px" src="<?php echo $block->getViewFileUrl('images/rule_component_apply.gif') ?>"/>
         <img class="fail" hidden="hidden" alt="Failed" style="margin:-3px 5px" src="<?php echo $block->getViewFileUrl('images/rule_component_remove.gif') ?>"/>
         <span id="send_checkout_message" style="vertical-align: middle;"></span>
+    </span>
+    <span class="collect-indicator" id="send_auth_span" style="display: block; margin-top: 1rem;">
+        <img class="processing" hidden="hidden" alt="Fetching" style="margin:0 5px; vertical-align: middle;" src="<?php echo $block->getViewFileUrl('images/process_spinner.gif') ?>"/>
+        <img class="success" hidden="hidden" alt="Success" style="margin:-3px 5px" src="<?php echo $block->getViewFileUrl('images/rule_component_apply.gif') ?>"/>
+        <img class="fail" hidden="hidden" alt="Failed" style="margin:-3px 5px" src="<?php echo $block->getViewFileUrl('images/rule_component_remove.gif') ?>"/>
+        <span id="send_auth_message" style="vertical-align: middle;"></span>
     </span>
 </div>
 <?php endif; ?>

--- a/view/frontend/layout/telesales_payment_success.xml
+++ b/view/frontend/layout/telesales_payment_success.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <referenceContainer name="content">
+        <block class="Affirm\Telesales\Block\Payment\Success" name="telesales_payment_success" template="Affirm_Telesales::success.phtml" />
+    </referenceContainer>
+</page>

--- a/view/frontend/templates/success.phtml
+++ b/view/frontend/templates/success.phtml
@@ -1,0 +1,9 @@
+<?php
+/**
+ * @var \Affirm\Telesales\Block\Payment\Success $block
+ */
+?>
+
+<h1 class="page-title">Order confirmed</h1>
+<p>Your order has been received.</p>
+


### PR DESCRIPTION
### CA Update for M2 Telesales
-------------
Currently, once telesales checkout is completed by the end customer, the confirmation redirect url is reached to initiate the auth request from the merchant's Magento server. 

To support CA, Telesales need to include country code and currency information in the authorization request to POST /transactions endpoint. However, since the confirm redirect parameter only includes checkout token (and no other information is passed to look up the currency or country code attributes of an order), this requirement poses a challenge. 

The proposed solution is to move the auth flow away from end customer reaching the confirm endpoint synchronously, and instead allowing admin user (in-store) to initiate the auth flow async once customer completes telesales checkout flow. As a result, one additional UI (refresh button) will be introduced to initiate the auth flow. 

![image](https://user-images.githubusercontent.com/9426310/204459083-f89ff57e-bf91-48da-8279-27d0357c84f6.png)
