### PR TITLE
Migrate from Zend to Laminas

### DIFF
--- a/Block/Adminhtml/Order/View.php
+++ b/Block/Adminhtml/Order/View.php
@@ -41,7 +41,7 @@ class View extends \Magento\Backend\Block\Template
         \Magento\Backend\Block\Template\Context $context,
         \Magento\Framework\Registry $registry,
         \Magento\Sales\Helper\Admin $adminHelper,
-        \Magento\Framework\HTTP\ZendClientFactory $httpClientFactory,
+        \Laminas\Http\Client $httpClientFactory,
         \Astound\Affirm\Model\Config $affirmConfig,
         Checkout $affirmCheckout,
         OrderManagement $orderManagement,
@@ -239,16 +239,14 @@ class View extends \Magento\Backend\Block\Template
 
         // Get order currency code
         $currencyCode = $this->getCurrencyCode();
-
         $readCheckoutResponse = $this->affirmCheckout->readCheckout($checkout_token, $currencyCode);
         if (isset($readCheckoutResponse)) {
-            $responseStatus = $readCheckoutResponse->getStatus();
+            $responseStatus = $readCheckoutResponse->getStatusCode();
             $responseBody = json_decode($readCheckoutResponse->getBody(), true);
             $checkout_status = $responseBody['checkout_status'] ?? null;
         } else {
             return null;
         }
-
         // Read transaction endpoint if transaction id exists
         $transaction_id = $this->getTransactionId();
         if ($transaction_id) {

--- a/Controller/Payment/Confirm.php
+++ b/Controller/Payment/Confirm.php
@@ -66,7 +66,7 @@ class Confirm extends Action implements CsrfAwareActionInterface
     * @inheritDoc
     */
     public function execute()
-    {
+    {   
         $result = $this->resultJsonFactory->create();
         $checkout_token = $this->getRequest()->getParam('checkout_token') ?? null;
         $currency_code = $this->getRequest()->getParam('currency_code') ?? 'USD';
@@ -84,7 +84,7 @@ class Confirm extends Action implements CsrfAwareActionInterface
         $checkout_status = '';
         try {
             $readCheckoutResponse = $this->affirmCheckout->readCheckout($checkout_token, $currency_code);
-            $response_date = $readCheckoutResponse->getHeader('Date');
+            $response_date = $readCheckoutResponse->getHeaders('Date');
             $this->logger->debug('Affirm Telesales checkout confirm responseBody: ' . $readCheckoutResponse->getBody());
             $responseBody = json_decode($readCheckoutResponse->getBody(), true);
             if (isset($responseBody['checkout_status'])) {
@@ -108,7 +108,6 @@ class Confirm extends Action implements CsrfAwareActionInterface
 
         // Order ID
         $order_id = $responseBody['merchant_external_reference'] ?? $responseBody['order_id'];
-
         if (!isset($order_id)) {
             $_message = __('Affirm Telesales - Missing merchant external reference');
             $this->logger->debug($_message);
@@ -148,7 +147,6 @@ class Confirm extends Action implements CsrfAwareActionInterface
 
         $_orderState = $order->getState();
         $_orderStatus = $order->getStatus();
-
         $this->_checkoutSession
             ->setLastQuoteId($quoteId)
             ->setLastSuccessQuoteId($quoteId);
@@ -156,7 +154,6 @@ class Confirm extends Action implements CsrfAwareActionInterface
             ->setLastOrderId($order->getId())
             ->setLastRealOrderId($order->getIncrementId())
             ->setLastOrderStatus($_orderStatus);
-
         $this->_eventManager->dispatch(
             'affirm_place_order_success',
             ['order' => $order, 'quote' => $quote ]

--- a/Controller/adminhtml/Checkout/Index.php
+++ b/Controller/adminhtml/Checkout/Index.php
@@ -9,7 +9,7 @@ use Magento\Backend\App\Action\Context;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Controller\Result\JsonFactory;
-use Magento\Framework\HTTP\ZendClientFactory;
+use Laminas\Http\Client;
 use Magento\Framework\Module\ResourceInterface;
 use Magento\Framework\Registry;
 use Magento\Sales\Api\Data\OrderStatusHistoryInterface;
@@ -31,7 +31,7 @@ class Index extends Action
         Context $context,
         JsonFactory $resultJsonFactory,
         Registry $coreRegistry,
-        ZendClientFactory $httpClientFactory,
+        Client $httpClientFactory,
         OrderRepositoryInterface $orderRepository,
         OrderStatusHistoryInterface $orderStatusRepository,
         ProductMetadataInterface $productMetadata,
@@ -96,7 +96,7 @@ class Index extends Action
         if ($checkout_token) {
             try {
                 $resendCheckoutResponse = $this->affirmCheckout->resendCheckout($checkout_token, $currency_code);
-                $responseStatus = $resendCheckoutResponse->getStatus();
+                $responseStatus = $resendCheckoutResponse->getStatusCode();
                 $responseBody = json_decode($resendCheckoutResponse->getBody(), true);
 
                 if ($responseStatus > 200) {
@@ -140,9 +140,8 @@ class Index extends Action
             try {
                 $currency_code = $order->getOrderCurrencyCode();
                 $sendCheckoutResponse = $this->affirmCheckout->sendCheckout($data, $currency_code);
-                $responseStatus = $sendCheckoutResponse->getStatus();
+                $responseStatus = $sendCheckoutResponse->getStatusCode();
                 $responseBody = json_decode($sendCheckoutResponse->getBody(), true);
-
                 if ($responseStatus > 200) {
                     $this->logger->debug('Affirm_Telesales__sendCheckout_status_code: ', [$responseStatus]);
                     $this->logger->debug('Affirm_Telesales__sendCheckout_response_body: ', [$responseBody]);
@@ -190,7 +189,6 @@ class Index extends Action
                 $this->logger->debug($e->getMessage());
             }
         }
-
         // Return JSON result
         return $result->setData([
             'success' => $success,


### PR DESCRIPTION
With Magento 2.4.6 the removed support for Zend in favor of Laminas.  This update migrate our extension to use laminas instead of zend