### PR TITLE
Support virtual item orders

### DIFF
--- a/Model/Adminhtml/Checkout.php
+++ b/Model/Adminhtml/Checkout.php
@@ -125,25 +125,6 @@ class Checkout extends \Magento\Framework\Model\AbstractModel
         }
 
         try {
-            $shippingAddress = $order->getShippingAddress();
-            $shippingObject = [
-                'name' => [
-                    'full_name' => $shippingAddress->getName(),
-                    'first' => $shippingAddress->getFirstname(),
-                    'last' => $shippingAddress->getLastname()
-                ],
-                'address'=>[
-                    'line1' => $shippingAddress->getStreetLine(1),
-                    'line2' => empty($shippingAddress->getStreetLine(2)) ? null : $shippingAddress->getStreetLine(2),
-                    'city' => $shippingAddress->getCity(),
-                    'state' => empty($shippingAddress->getRegionCode()) ? $this->getRegionCode($shippingAddress->getRegionId()) : $shippingAddress->getRegionCode(),
-                    'zipcode' => $shippingAddress->getPostcode(),
-                    'country' => $shippingAddress->getCountryId()
-                ],
-                'email' => $shippingAddress->getEmail(),
-                'phone_number' => $shippingAddress->getTelephone()
-            ];
-
             $billingAddress = $order->getBillingAddress();
             $billingObject = [
                 'name' => [
@@ -162,6 +143,30 @@ class Checkout extends \Magento\Framework\Model\AbstractModel
                 'email' => $billingAddress->getEmail(),
                 'phone_number' => $billingAddress->getTelephone()
             ];
+
+            $shippingAddress = $order->getShippingAddress();
+            if (!$shippingAddress || $order->getData('is_virtual')) {
+                $shippingObject = $billingObject;
+            } else {
+                $shippingAddress = $order->getShippingAddress();
+                $shippingObject = [
+                    'name' => [
+                        'full_name' => $shippingAddress->getName(),
+                        'first' => $shippingAddress->getFirstname(),
+                        'last' => $shippingAddress->getLastname()
+                    ],
+                    'address'=>[
+                        'line1' => $shippingAddress->getStreetLine(1),
+                        'line2' => empty($shippingAddress->getStreetLine(2)) ? null : $shippingAddress->getStreetLine(2),
+                        'city' => $shippingAddress->getCity(),
+                        'state' => empty($shippingAddress->getRegionCode()) ? $this->getRegionCode($shippingAddress->getRegionId()) : $shippingAddress->getRegionCode(),
+                        'zipcode' => $shippingAddress->getPostcode(),
+                        'country' => $shippingAddress->getCountryId()
+                    ],
+                    'email' => $shippingAddress->getEmail(),
+                    'phone_number' => $shippingAddress->getTelephone()
+                ];
+            }
 
             $_items = [];
             foreach ($order->getAllItems() as $item) {


### PR DESCRIPTION
As it currently appears to stand, Affirm's Telesales endpoint (`/api/v2/checkout/telesales`) requires shipping address and name to be passed (to be confirmed internally) otherwise returns a 400 response. In order to support virtual item orders whose order info do not include shipping address, this commit will copy the billing address and pass to the shipping address attribute of the checkout object. 