### PR TITLE
Send errors back to Affirm's error tracker

### DIFF
--- a/Controller/adminhtml/Checkout/Index.php
+++ b/Controller/adminhtml/Checkout/Index.php
@@ -14,6 +14,7 @@ use Magento\Framework\Module\ResourceInterface;
 use Magento\Framework\Registry;
 use Magento\Sales\Api\Data\OrderStatusHistoryInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
+use Astound\Affirm\Helper\ErrorTracker;
 
 class Index extends Action
 {
@@ -39,7 +40,8 @@ class Index extends Action
         ScopeConfigInterface $scopeConfig,
         ConfigAffirm $configAffirm,
         Checkout $affirmCheckout,
-        \Psr\Log\LoggerInterface $logger
+        \Psr\Log\LoggerInterface $logger,
+        ErrorTracker $errorTracker
     ) {
         $this->resultJsonFactory = $resultJsonFactory;
         $this->_coreRegistry = $coreRegistry;
@@ -52,6 +54,7 @@ class Index extends Action
         $this->affirmConfig = $configAffirm;
         $this->affirmCheckout = $affirmCheckout;
         $this->logger = $logger;
+        $this->errorTracker = $errorTracker;
         parent::__construct($context);
     }
 
@@ -102,6 +105,12 @@ class Index extends Action
                 if ($responseStatus > 200) {
                     $this->logger->debug('Affirm_Telesales__resendCheckout_status_code: ', [$responseStatus]);
                     $this->logger->debug('Affirm_Telesales__resendCheckout_response_body: ', [$responseBody]);
+                    $this->errorTracker->logErrorToAffirm(
+                        transaction_step: 'pre_auth',
+                        error_type: ErrorTracker::TRANSACTION_DECLINED,
+                        error_message: $resendCheckoutResponse->getMessage(),
+                        is_telesales: true
+                    );
                     return $result->setData([
                         'success' => false,
                         'message' => $resendCheckoutResponse->getMessage(),
@@ -115,6 +124,12 @@ class Index extends Action
                 $successMessage = 'Checkout link was re-sent successfully';
             } catch (\Exception $e) {
                 $this->logger->debug($e->getMessage());
+                $this->errorTracker->logErrorToAffirm(
+                    transaction_step: 'pre_auth',
+                    error_type: ErrorTracker::INTERNAL_SERVER_ERROR,
+                    exception: $e,
+                    is_telesales: true
+                );
                 return $result->setData([
                     'success' => false,
                     'message' => "Error",
@@ -146,6 +161,12 @@ class Index extends Action
                     $this->logger->debug('Affirm_Telesales__sendCheckout_status_code: ', [$responseStatus]);
                     $this->logger->debug('Affirm_Telesales__sendCheckout_response_body: ', [$responseBody]);
                     $bodyMessage = $responseBody['message'] && $responseBody['field'] ? "{$responseBody['message']} ({$responseBody['field']})" : "API Error - Affirm checkout could not be processed";
+                    $this->errorTracker->logErrorToAffirm(
+                        transaction_step: 'pre_auth',
+                        error_type: ErrorTracker::TRANSACTION_DECLINED,
+                        error_message: $sendCheckoutResponse->getMessage(),
+                        is_telesales: true
+                    );
                     return $result->setData([
                         'success' => false,
                         'message' => $sendCheckoutResponse->getMessage(),
@@ -162,6 +183,12 @@ class Index extends Action
                 $checkout_token = $responseBody['checkout_id'];
             } catch (\Exception $e) {
                 $this->logger->debug($e->getMessage());
+                $this->errorTracker->logErrorToAffirm(
+                    transaction_step: 'pre_auth',
+                    error_type: ErrorTracker::INTERNAL_SERVER_ERROR,
+                    exception: $e,
+                    is_telesales: true
+                );
                 return $result->setData([
                     'success' => false,
                     'message' => 'API Error - Affirm checkout could not be processed',
@@ -177,6 +204,12 @@ class Index extends Action
                 $payment->setAdditionalInformation('checkout_token', $checkout_token);
                 $payment->save();
             } catch (\Exception $e) {
+                $this->errorTracker->logErrorToAffirm(
+                    transaction_step: 'pre_auth',
+                    error_type: ErrorTracker::INTERNAL_SERVER_ERROR,
+                    exception: $e,
+                    is_telesales: true
+                );
                 $this->logger->debug($e->getMessage());
             }
 
@@ -186,6 +219,12 @@ class Index extends Action
             try {
                 $this->orderRepository->save($order);
             } catch (\Exception $e) {
+                $this->errorTracker->logErrorToAffirm(
+                    transaction_step: 'pre_auth',
+                    error_type: ErrorTracker::INTERNAL_SERVER_ERROR,
+                    exception: $e,
+                    is_telesales: true
+                );
                 $this->logger->debug($e->getMessage());
             }
         }


### PR DESCRIPTION
---
Send errors back to Affirm's error tracker
---

### Description
Errors that fail locally are hard to track and monitor since they are not sent back to Affirm. By sending a request containing error information back to our Affirm endpoint, we will be able to observe errors through Chronosphere, Kibana, and Rollbar to help alert us of any issues that arise.

See [this PR](https://github.com/Affirm/Magento2_Affirm/pull/117) for more information
