### PR TITLE
Bumping version to support PHP8.3

### DIFF
--- a/Controller/Payment/Confirm.php
+++ b/Controller/Payment/Confirm.php
@@ -24,6 +24,57 @@ class Confirm extends Action implements CsrfAwareActionInterface
      *
      * @param Context                 $context
      */
+
+     /**
+     * @var JsonFactory
+     */
+    private $resultJsonFactory;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var Checkout
+     */
+    private $affirmCheckout;
+
+    /**
+     * @var ConfigAffirm
+     */
+    private $affirmConfig;
+
+    /**
+     * @var ErrorTracker
+     */
+    private $errorTracker;
+
+    /**
+     * @var Session
+     */
+    private $_checkoutSession;
+
+    /**
+     * @var CartManagementInterface
+     */
+    private $quoteManagement;
+
+    /**
+     * @var OrderFactory
+     */
+    private $orderFactory;
+
+    /**
+     * @var OrderManagement
+     */
+    private $orderManagement;
+
+    /**
+     * @var CartRepositoryInterface
+     */
+    private $quoteRepository;
+
     public function __construct(
         Context $context,
         Session $checkoutSession,

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "affirm/m2-telesales",
     "description": "Affirm Telesales extension for the Magento 2 https://www.affirm.com/",
     "type": "magento2-module",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "license": [
         "BSD-3-Clause"
     ],

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Affirm_Telesales" setup_version="1.2.1">
+    <module name="Affirm_Telesales" setup_version="1.2.2">
         <sequence>
             <module name="Astound_Affirm"/>
             <module name="Magento_Store"/>


### PR DESCRIPTION
Updating extension to define missing variables for PHP 8 support.  PHP 8 deprecated the use of dynamic variables.