### PR TITLE
[MAPI-5357] Fix Laminas Headers object string conversion error in admin refresh

### DIFF
--- a/Controller/Payment/Confirm.php
+++ b/Controller/Payment/Confirm.php
@@ -139,7 +139,7 @@ class Confirm extends Action implements CsrfAwareActionInterface
         try {
             $readCheckoutResponse = $this->affirmCheckout->readCheckout($checkout_token, $currency_code);
             $dateHeader = $readCheckoutResponse->getHeaders()->get('Date');
-            $response_date = $dateHeader ? $dateHeader->getFieldValue() : '';
+            $response_date = $dateHeader ? $dateHeader->getFieldValue() : null;
             $this->logger->debug('Affirm Telesales checkout confirm responseBody: ' . $readCheckoutResponse->getBody());
             $responseBody = json_decode($readCheckoutResponse->getBody(), true);
             if (isset($responseBody['checkout_status'])) {
@@ -160,7 +160,9 @@ class Confirm extends Action implements CsrfAwareActionInterface
         if ($checkout_status !== 'confirmed' && $checkout_status !=='authorized') {
             $result->setData([
                 'success' => true,
-                'message' => "Last refreshed: " . $response_date,
+                'message' => $response_date
+                    ? "Last refreshed: " . $response_date
+                    : "Click refresh to check latest status",
                 'checkout_status' => "Application sent",
                 'checkout_status_message' => "Waiting for customer to start the application"
             ]);

--- a/Controller/Payment/Confirm.php
+++ b/Controller/Payment/Confirm.php
@@ -138,7 +138,7 @@ class Confirm extends Action implements CsrfAwareActionInterface
         $checkout_status = '';
         try {
             $readCheckoutResponse = $this->affirmCheckout->readCheckout($checkout_token, $currency_code);
-            $response_date = $readCheckoutResponse->getHeaders('Date');
+            $response_date = $readCheckoutResponse->getHeader('Date') ? $readCheckoutResponse->getHeader('Date')->getFieldValue() : '';
             $this->logger->debug('Affirm Telesales checkout confirm responseBody: ' . $readCheckoutResponse->getBody());
             $responseBody = json_decode($readCheckoutResponse->getBody(), true);
             if (isset($responseBody['checkout_status'])) {

--- a/Controller/Payment/Confirm.php
+++ b/Controller/Payment/Confirm.php
@@ -138,7 +138,8 @@ class Confirm extends Action implements CsrfAwareActionInterface
         $checkout_status = '';
         try {
             $readCheckoutResponse = $this->affirmCheckout->readCheckout($checkout_token, $currency_code);
-            $response_date = $readCheckoutResponse->getHeader('Date') ? $readCheckoutResponse->getHeader('Date')->getFieldValue() : '';
+            $dateHeader = $readCheckoutResponse->getHeaders()->get('Date');
+            $response_date = $dateHeader ? $dateHeader->getFieldValue() : '';
             $this->logger->debug('Affirm Telesales checkout confirm responseBody: ' . $readCheckoutResponse->getBody());
             $responseBody = json_decode($readCheckoutResponse->getBody(), true);
             if (isset($responseBody['checkout_status'])) {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "affirm/m2-telesales",
     "description": "Affirm Telesales extension for the Magento 2 https://www.affirm.com/",
     "type": "magento2-module",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "license": [
         "BSD-3-Clause"
     ],

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Affirm_Telesales" setup_version="1.2.2">
+    <module name="Affirm_Telesales" setup_version="1.2.3">
         <sequence>
             <module name="Astound_Affirm"/>
             <module name="Magento_Store"/>


### PR DESCRIPTION
## Summary
Fixes the 500 Internal Server Error that occurs when clicking the **Affirm > Refresh** button in the Admin order view.

**Version:** 1.2.3  
**JIRA:** [MAPI-5357](MAPI-5357)  

---

## The Problem

### Original Error
```
Error: Object of class Laminas\Http\Headers could not be converted to string 
in /var/www/html/vendor/affirm/magento2-telesales/Controller/Payment/Confirm.php:162
```

### Root Cause Analysis

The bug was in `Controller/Payment/Confirm.php` at line 141:

```php
$response_date = $readCheckoutResponse->getHeaders('Date');
```

**Why this failed:**
1. The method `getHeaders('Date')` doesn't exist in Laminas\Http\Response
2. Even if it did, `getHeaders()` returns a `Laminas\Http\Headers` **collection object**, not a string
3. On line 162, the code tried to concatenate this object with a string:
   ```php
   'message' => "Last refreshed: " . $response_date,
   ```
4. PHP cannot automatically convert a Headers object to a string, resulting in a fatal error

**What was happening:**
- The code was trying to get the 'Date' header value to display when the checkout was last refreshed
- It used the wrong API method, getting back an object instead of a string value
- When PHP tried to concatenate the object in the response message, it crashed with a 500 error

---

## The Solution

### Correct Implementation

**File:** `Controller/Payment/Confirm.php` (lines 141-142)

```php
$dateHeader = $readCheckoutResponse->getHeaders()->get('Date');
$response_date = $dateHeader ? $dateHeader->getFieldValue() : '';
```

### Why This Works

The correct Laminas HTTP API pattern is:

1. **`getHeaders()`** - Returns the Headers collection object
2. **`->get('Date')`** - Retrieves the specific Date header object from the collection
3. **`->getFieldValue()`** - Extracts the actual header value as a **string**
4. **Null safety check** - Handles cases where the Date header might not be present

This follows the proper object-oriented approach in Laminas:
- Headers collection → Header object → String value

Instead of trying to get the string directly (which doesn't work), we properly traverse the object hierarchy.

---

## Changes Made

### Code Fix
- **File:** `Controller/Payment/Confirm.php`
- **Lines:** 141-142
- **Change:** Use correct Laminas API chain to extract Date header as string

### Version Bump
- **composer.json:** `1.2.2` → `1.2.3`
- **etc/module.xml:** `setup_version="1.2.2"` → `setup_version="1.2.3"`

---

## Impact

**Before:**
- ❌ Clicking "Refresh" button → 500 Internal Server Error
- ❌ Admins cannot check checkout status
- ❌ Error logged in Magento logs

**After:**
- ✅ Clicking "Refresh" button works correctly
- ✅ Displays "Last refreshed: [timestamp]" message
- ✅ Proper checkout status updates in admin UI

---

## Test Plan

- [ ] Click "Refresh" button in Admin order view under Affirm section
- [ ] Verify no 500 error occurs
- [ ] Verify "Last refreshed: [date/time]" message displays correctly with timestamp
- [ ] Test with orders in different checkout states:
  - [ ] Application sent (waiting for customer)
  - [ ] Confirmed
  - [ ] Authorized
- [ ] Verify error tracking still works correctly

---

## Technical Details

**Laminas HTTP Response API:**
```php
// ❌ WRONG - getHeaders() doesn't accept parameters
$response->getHeaders('Date')

// ❌ WRONG - getHeader() method doesn't exist on Response
$response->getHeader('Date')

// ✅ CORRECT - Proper object chain
$response->getHeaders()->get('Date')->getFieldValue()
```

**References:**
- [Laminas HTTP Documentation](https://docs.laminas.dev/laminas-http/)
- Similar issue fixed in other Magento extensions using Laminas

---

## Screenshots
_Screenshots will be attached shortly_
## Error Reproduced
<img width="1073" height="442" alt="Screenshot 2026-04-23 at 12 38 09 PM" src="https://github.com/user-attachments/assets/43dabe2f-982d-489f-818c-c0c959e0fce4" />


##After Fix
<img width="1083" height="464" alt="Screenshot 2026-04-23 at 12 37 02 PM" src="https://github.com/user-attachments/assets/ae8746d0-b8fa-47cf-9a75-148e0cca594f" />

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MAPI-5357]: https://affirm.atlassian.net/browse/MAPI-5357
[CMT-0000]: https://affirm.atlassian.net/browse/MAPI-4588

[MAPI-4588]: https://affirm.atlassian.net/browse/MAPI-4588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ