### PR TITLE
[MAPI-5640] Add PHP 8.4 compatibility support

### DIFF
--- a/Model/Adminhtml/Checkout.php
+++ b/Model/Adminhtml/Checkout.php
@@ -300,7 +300,7 @@ class Checkout extends \Magento\Framework\Model\AbstractModel
      * @param string|null $currencyCode
      * @return \Http_Response|null
      */
-    protected function _apiRequestClient($url, $data = null, bool $requireKeys = false, string $method = self::METHOD_POST, string $currencyCode = null)
+    protected function _apiRequestClient($url, $data = null, bool $requireKeys = false, string $method = self::METHOD_POST, ?string $currencyCode = null)
     {
         try {
             $client = $this->httpClientFactory;

--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,13 @@
     "name": "affirm/m2-telesales",
     "description": "Affirm Telesales extension for the Magento 2 https://www.affirm.com/",
     "type": "magento2-module",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "license": [
         "BSD-3-Clause"
     ],
+    "require": {
+        "php": "^8.0"
+    },
     "repositories": [
         {
             "type": "composer",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Affirm_Telesales" setup_version="1.2.3">
+    <module name="Affirm_Telesales" setup_version="1.2.4">
         <sequence>
             <module name="Astound_Affirm"/>
             <module name="Magento_Store"/>


### PR DESCRIPTION
## Summary
- Fixed PHP 8.4 nullable parameter deprecation in `_apiRequestClient` method
- Added explicit PHP version constraint (^8.0) to composer.json
- Bumped version from 1.2.3 to 1.2.4

## Context
Boost Mobile Telesales is upgrading from Magento 2.4.7-p7 to 2.4.8-p5 with PHP 8.4 and encountered PHP 8.4 compatibility issues with the Affirm Telesales plugin. PHP 8.4 deprecates implicitly-nullable typed parameters.

## Changes
1. **Model/Adminhtml/Checkout.php** - Changed `string $currencyCode = null` to `?string $currencyCode = null` in the `_apiRequestClient` method signature (line 303)
2. **composer.json** - Added PHP version requirement and bumped version to 1.2.4
3. **etc/module.xml** - Updated setup_version to 1.2.4

## Testing
This change maintains backward compatibility while adding PHP 8.4 support. The nullable type hint is explicit rather than implicit, which is required for PHP 8.4.

Resolves: https://affirm.atlassian.net/browse/MAPI-5640


build failing with latest version of magento straight up fails today so we should fix this asap
<img width="1553" height="334" alt="image (22)" src="https://github.com/user-attachments/assets/11200a71-1b79-4ad2-9799-573e0173f5bf" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)