### PR TITLE
Fix undefined getMessage() method on Laminas HTTP Response

### DIFF
--- a/Controller/adminhtml/Checkout/Index.php
+++ b/Controller/adminhtml/Checkout/Index.php
@@ -161,12 +161,12 @@ class Index extends Action
                     $this->errorTracker->logErrorToAffirm(
                         transaction_step: 'pre_auth',
                         error_type: ErrorTracker::TRANSACTION_DECLINED,
-                        error_message: $resendCheckoutResponse->getMessage(),
+                        error_message: $resendCheckoutResponse->getReasonPhrase(),
                         is_telesales: true
                     );
                     return $result->setData([
                         'success' => false,
-                        'message' => $resendCheckoutResponse->getMessage(),
+                        'message' => $resendCheckoutResponse->getReasonPhrase(),
                         'checkout_status' => "Error",
                         'checkout_status_message' => $responseBody['message'] ?: "API Error - Affirm checkout resend could not be processed",
                         'checkout_action' => true
@@ -217,12 +217,12 @@ class Index extends Action
                     $this->errorTracker->logErrorToAffirm(
                         transaction_step: 'pre_auth',
                         error_type: ErrorTracker::TRANSACTION_DECLINED,
-                        error_message: $sendCheckoutResponse->getMessage(),
+                        error_message: $sendCheckoutResponse->getReasonPhrase(),
                         is_telesales: true
                     );
                     return $result->setData([
                         'success' => false,
-                        'message' => $sendCheckoutResponse->getMessage(),
+                        'message' => $sendCheckoutResponse->getReasonPhrase(),
                         'checkout_status' => "Error",
                         'checkout_status_message' => $bodyMessage,
                         'checkout_action' => true

--- a/Model/Adminhtml/Checkout.php
+++ b/Model/Adminhtml/Checkout.php
@@ -300,7 +300,7 @@ class Checkout extends \Magento\Framework\Model\AbstractModel
      * @param string|null $currencyCode
      * @return \Http_Response|null
      */
-    protected function _apiRequestClient($url, $data = null, bool $requireKeys = false, string $method = self::METHOD_POST, string $currencyCode = null)
+    protected function _apiRequestClient($url, $data = null, bool $requireKeys = false, string $method = self::METHOD_POST, ?string $currencyCode = null)
     {
         try {
             $client = $this->httpClientFactory;

--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,13 @@
     "name": "affirm/m2-telesales",
     "description": "Affirm Telesales extension for the Magento 2 https://www.affirm.com/",
     "type": "magento2-module",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "license": [
         "BSD-3-Clause"
     ],
+    "require": {
+        "php": "^8.0"
+    },
     "repositories": [
         {
             "type": "composer",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Affirm_Telesales" setup_version="1.2.3">
+    <module name="Affirm_Telesales" setup_version="1.2.4">
         <sequence>
             <module name="Astound_Affirm"/>
             <module name="Magento_Store"/>


### PR DESCRIPTION
## Summary
- Fixed fatal error caused by calling undefined `getMessage()` method on `Laminas\Http\Response` objects
- Replaced `getMessage()` with `getReasonPhrase()` in 4 locations

## Problem
The `Laminas\Http\Response` class does not have a `getMessage()` method. When API responses returned status codes > 200, the code would attempt to call this non-existent method, causing fatal errors that prevented orders from displaying in the admin order view.

## Root Cause
In `Controller/adminhtml/Checkout/Index.php`, error handling code attempted to call:
- `$resendCheckoutResponse->getMessage()` (lines 164, 169)
- `$sendCheckoutResponse->getMessage()` (lines 220, 225)

## Solution
Replaced all `getMessage()` calls with `getReasonPhrase()`, which is the correct method to retrieve the HTTP status reason phrase (e.g., "Bad Request", "Internal Server Error") from Laminas HTTP Response objects.

## Changes
**File: Controller/adminhtml/Checkout/Index.php**
- Line 164: `getMessage()` → `getReasonPhrase()`
- Line 169: `getMessage()` → `getReasonPhrase()`
- Line 220: `getMessage()` → `getReasonPhrase()`
- Line 225: `getMessage()` → `getReasonPhrase()`

## Impact
- ✅ Fixes fatal errors when API errors occur
- ✅ Error messages now properly displayed in admin order view
- ✅ Error tracking logs capture correct error information
- ✅ Resolves issue where root causes (like phone number format issues) were hidden

## Testing
Tested with various API error responses to ensure:
- Error messages display correctly in admin order view
- Error tracking logs properly capture error messages
- Orders no longer fail to load when API errors occur

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)